### PR TITLE
fix: include types in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./sync": {
+      "types": "./sync/index.d.ts",
       "import": "./sync/index.mjs",
       "require": "./sync/index.js"
     }


### PR DESCRIPTION
In order to support the `Node16`/`NodeNext` module resolution strategy, types need to be added to the exports map.

Docs: https://www.typescriptlang.org/tsconfig#moduleResolution